### PR TITLE
Add function to remove style tag from fontManager instances

### DIFF
--- a/src/FontManager/FontManager.js
+++ b/src/FontManager/FontManager.js
@@ -172,4 +172,11 @@ export default class FontManager {
 		checkFullFont(this.activeFont, this.options.variants, this.onChange);
 		return listIndex;
 	}
+	
+	/**
+	 * Remove the stylesheet of the current instance
+	 */
+	removeCustomStyle() {
+		this.styleManager.removePreviewStyle();
+	}
 }

--- a/src/FontManager/StyleManager.js
+++ b/src/FontManager/StyleManager.js
@@ -75,4 +75,11 @@ export default class StyleManager {
 		`;
 		this.stylesheet.replaceChild(document.createTextNode(style), this.stylesheet.childNodes[0]);
 	}
+
+	/**
+	 * Remove the stylesheet of the current instance
+	 */
+	removePreviewStyle() {
+		this.stylesheet.parentElement.removeChild(this.stylesheet)
+	}
 }


### PR DESCRIPTION
This PR allows developers to choose to remove the `style` tags generated from the fontManager instances.

For connivence a helper method is added to Style manager class as well